### PR TITLE
Add per-address cycle histogram for line-level profiling 

### DIFF
--- a/include/profiler.h
+++ b/include/profiler.h
@@ -43,6 +43,7 @@ enum class ProfileMode {
 struct ProfileOptions {
     ProfileMode mode = ProfileMode::Simple;
     uint32_t sample_rate = 1;  // 1 = every instruction, N = every Nth instruction
+    bool collect_address_histogram = false;  // Collect per-address cycle counts
 };
 
 /**
@@ -189,6 +190,25 @@ public:
     void PrintReport(std::ostream& out, size_t max_functions = 0) const;
 
     // -------------------------------------------------------------------------
+    // Address Histogram (for line-by-line profiling)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get per-address cycle histogram
+     * @return Map of PC address to cycles spent at that address
+     */
+    const std::unordered_map<uint32_t, uint64_t>& GetAddressHistogram() const {
+        return address_cycles_;
+    }
+
+    /**
+     * Write address histogram to JSON file for use with disassembly viewer
+     * @param path Output file path
+     * @return true on success
+     */
+    bool WriteAddressHistogram(const std::string& path) const;
+
+    // -------------------------------------------------------------------------
     // Internal (called by cpu_hook)
     // -------------------------------------------------------------------------
 
@@ -210,10 +230,12 @@ private:
 
     std::vector<FunctionDef> functions_;  // Sorted by start_addr
     std::unordered_map<uint32_t, FunctionStats> stats_;
+    std::unordered_map<uint32_t, uint64_t> address_cycles_;  // Per-address histogram
     std::vector<CallFrame> call_stack_;   // For CallStack mode
 
     ProfileMode mode_ = ProfileMode::Simple;
     bool running_ = false;
+    bool collect_address_histogram_ = false;
     uint32_t last_pc_ = 0;
     int64_t last_cycles_ = 0;
     uint64_t total_cycles_ = 0;

--- a/include/profiler.h
+++ b/include/profiler.h
@@ -43,7 +43,14 @@ enum class ProfileMode {
 struct ProfileOptions {
     ProfileMode mode = ProfileMode::Simple;
     uint32_t sample_rate = 1;  // 1 = every instruction, N = every Nth instruction
-    bool collect_address_histogram = false;  // Collect per-address cycle counts
+
+    // Collect per-address cycle counts for line-level profiling.
+    // NOTE: When sample_rate > 1, only every Nth instruction's address is
+    // recorded, with all accumulated cycles attributed to that address. This
+    // reduces granularity significantly. For accurate line-level profiling,
+    // use sample_rate = 1. Sampling is still useful for reducing overhead when
+    // only function-level stats are needed.
+    bool collect_address_histogram = false;
 };
 
 /**

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -392,7 +392,9 @@ bool Profiler::WriteAddressHistogram(const std::string& path) const {
         return false;
     }
 
-    // Write JSON format for use with disassembly viewer
+    // Write JSON format for use with disassembly viewer.
+    // Note: Stream error state persists across writes, so out.good() at the
+    // end correctly detects any intermediate write failures.
     out << "{\n";
     out << "  \"sample_rate\": " << sample_rate_ << ",\n";
     out << "  \"total_cycles\": " << total_cycles_ << ",\n";

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -170,6 +170,7 @@ void Profiler::Start(const ProfileOptions& options) {
 
     mode_ = options.mode;
     sample_rate_ = options.sample_rate > 0 ? options.sample_rate : 1;
+    collect_address_histogram_ = options.collect_address_histogram;
     sample_counter_ = 0;
     pending_cycles_ = 0;
     g_active_profiler = this;
@@ -192,6 +193,7 @@ void Profiler::Reset() {
     for (auto& kv : stats_) {
         kv.second = FunctionStats();
     }
+    address_cycles_.clear();
     call_stack_.clear();
     total_cycles_ = 0;
     pending_cycles_ = 0;
@@ -260,6 +262,11 @@ void Profiler::OnExecute(uint32_t pc) {
         // Use accumulated cycles since last sample (more accurate than scaling)
         delta = pending_cycles_;
         pending_cycles_ = 0;
+    }
+
+    // Collect per-address histogram if enabled
+    if (collect_address_histogram_) {
+        address_cycles_[pc] += delta;
     }
 
     // Attribute cycles to current function
@@ -377,6 +384,38 @@ void Profiler::PrintReport(std::ostream& out, size_t max_functions) const {
     out << std::setw(30) << std::left << "Total"
         << std::setw(12) << std::right << total_cycles_
         << "\n";
+}
+
+bool Profiler::WriteAddressHistogram(const std::string& path) const {
+    std::ofstream out(path);
+    if (!out) {
+        return false;
+    }
+
+    // Write JSON format for use with disassembly viewer
+    out << "{\n";
+    out << "  \"sample_rate\": " << sample_rate_ << ",\n";
+    out << "  \"total_cycles\": " << total_cycles_ << ",\n";
+    out << "  \"address_count\": " << address_cycles_.size() << ",\n";
+    out << "  \"addresses\": {\n";
+
+    // Sort addresses for deterministic output
+    std::vector<std::pair<uint32_t, uint64_t>> sorted_addrs(
+        address_cycles_.begin(), address_cycles_.end());
+    std::sort(sorted_addrs.begin(), sorted_addrs.end());
+
+    bool first = true;
+    for (const auto& kv : sorted_addrs) {
+        if (!first) out << ",\n";
+        first = false;
+        out << "    \"" << std::hex << std::setfill('0') << std::setw(8)
+            << kv.first << "\": " << std::dec << kv.second;
+    }
+
+    out << "\n  }\n";
+    out << "}\n";
+
+    return out.good();
 }
 
 bool Profiler::IsCallOpcode(uint16_t opcode) const {

--- a/tests/profiler_test.cpp
+++ b/tests/profiler_test.cpp
@@ -430,7 +430,10 @@ TEST_F(ProfilerTest, AddressHistogramWithSampling) {
     // at the time profiling stopped (at most sample_rate * cycles_per_instruction).
     uint64_t total_cycles = profiler.GetTotalCycles();
     uint64_t max_variance = opts.sample_rate * 200;  // ~200 cycles max per 68k instruction
-    EXPECT_LE(total_cycles - histogram_total, max_variance)
+    uint64_t diff = (total_cycles > histogram_total)
+                        ? (total_cycles - histogram_total)
+                        : (histogram_total - total_cycles);
+    EXPECT_LE(diff, max_variance)
         << "Histogram total should be within " << max_variance << " of total cycles";
     EXPECT_GE(histogram_total, total_cycles * 99 / 100)
         << "Histogram should capture at least 99% of cycles";

--- a/tests/profiler_test.cpp
+++ b/tests/profiler_test.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -466,7 +467,7 @@ TEST_F(ProfilerTest, WriteAddressHistogramJSON) {
     profiler.Stop();
 
     // Write to temp file
-    std::string temp_path = "/tmp/gxtest_histogram_test.json";
+    std::string temp_path = (std::filesystem::temp_directory_path() / "gxtest_histogram_test.json").string();
     ASSERT_TRUE(profiler.WriteAddressHistogram(temp_path))
         << "WriteAddressHistogram should succeed";
 
@@ -518,7 +519,7 @@ TEST_F(ProfilerTest, WriteAddressHistogramRecordsSampleRate) {
     emu.RunUntilMemoryEquals(DONE_FLAG_ADDR + 1, 0xAD, 60);
     profiler.Stop();
 
-    std::string temp_path = "/tmp/gxtest_histogram_sample_test.json";
+    std::string temp_path = (std::filesystem::temp_directory_path() / "gxtest_histogram_sample_test.json").string();
     ASSERT_TRUE(profiler.WriteAddressHistogram(temp_path));
 
     std::ifstream file(temp_path);


### PR DESCRIPTION
  ## Summary                                                                                                                            
                                                                                                                                        
  - Add `collect_address_histogram` option to `ProfileOptions`                                                                          
  - Track CPU cycles per instruction address in `OnExecute()`                                                                           
  - Add `GetAddressHistogram()` to retrieve the per-address cycle map                                                                   
  - Add `WriteAddressHistogram()` to export JSON for disassembly viewer integration                                                     
                                                                                                                                        
  ## JSON Output Format                                                                                                                 
                                                                                                                                        
  ```json                                                                                                                               
  {                                                                                                                                     
    "sample_rate": 1,                                                                                                                   
    "total_cycles": 1007454,                                                                                                            
    "address_count": 42,                                                                                                                
    "addresses": {                                                                                                                      
      "00000236": 523000,                                                                                                               
      "0000023a": 412000                                                                                                                
    }                                                                                                                                   
  }                                                                                                                                     
                                                                                                                                        
  Test Coverage                                                                                                                         
                                                                                                                                        
  - AddressHistogramDisabledByDefault: verify empty when not enabled                                                                    
  - AddressHistogramCollected: verify populated when enabled                                                                            
  - AddressHistogramSumsToTotal: verify sum equals total cycles                                                                         
  - AddressHistogramWithSampling: verify works with sampling                                                                            
  - ResetClearsAddressHistogram: verify Reset() clears histogram                                                                        
  - WriteAddressHistogramJSON: verify JSON output structure                                                                             
  - WriteAddressHistogramRecordsSampleRate: verify sample_rate in JSON                                                                  
  - WriteAddressHistogramInvalidPath: verify graceful failure                                                                           
  - AddressHistogramContainsKnownAddresses: verify expected addresses                                                                   
                                                                                                                                        
  🤖 Generated with https://claude.ai/code                                                                                              
  ```                                                                                                                                   
                               